### PR TITLE
feat: Add character model and preferences datastore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,4 +53,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.gif.drawable)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore.preferences.core)
+    implementation(libs.gson)
 }

--- a/app/src/main/java/com/samrraa/qurioapp/datastore/QurioPreferences.kt
+++ b/app/src/main/java/com/samrraa/qurioapp/datastore/QurioPreferences.kt
@@ -1,0 +1,40 @@
+package com.samrraa.qurioapp.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.google.gson.Gson
+import com.samrraa.qurioapp.model.Character
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+const val PREFERENCES_NAME = "qurio_preferences"
+private val Context.dataStore by preferencesDataStore(
+    name = PREFERENCES_NAME
+)
+
+
+class QurioPreferences(private val context: Context) {
+
+    suspend fun storeCharacter(character: Character) {
+        context.dataStore.edit {
+            it[CHARACTER_KEY] = Gson().toJson(character)
+        }
+    }
+
+    val characterFlow: Flow<Character> = context.dataStore.data
+        .map { preferences ->
+            val characterJsonString = preferences[CHARACTER_KEY]
+            if (characterJsonString != null) {
+                Gson().fromJson(characterJsonString, Character::class.java)
+            } else {
+                Character.RIKA
+            }
+        }
+
+
+    private companion object {
+        val CHARACTER_KEY = stringPreferencesKey("USER_NAME")
+    }
+}

--- a/app/src/main/java/com/samrraa/qurioapp/model/Character.kt
+++ b/app/src/main/java/com/samrraa/qurioapp/model/Character.kt
@@ -1,0 +1,71 @@
+package com.samrraa.qurioapp.model
+
+enum class Character(
+    val displayName: String,
+    val age: Int,
+    val power: String,
+    val description: String
+) {
+    RIKA(
+        displayName = "Rika",
+        age = 12,
+        power = "Sunblooms",
+        description = "Nature’s little explorer! Rika talks to mushrooms and swears squirrels give her battle advice. Always ready for an adventure."
+    ),
+
+    KAIYO(
+        displayName = "Kaiyo",
+        age = 14,
+        power = "Storms",
+        description = "A calm storm in human form. Kaiyo trains with ancient scrolls by day and drinks spicy tea by night. Sword sharp, heart sharper."
+    ),
+
+    MIMI(
+        displayName = "Mimi",
+        age = 10,
+        power = "Volcano Puffs",
+        description = "Tiny but terrifying! Mimi is always grumpy, but don’t let that scare you—unless you like pranks involving firecrackers."
+    ),
+
+    YORU(
+        displayName = "Yoru",
+        age = 13,
+        power = "Shadows",
+        description = "Quiet, mysterious, and probably watching you right now. Yoru shows up when you least expect it."
+    ),
+
+    KURO(
+        displayName = "Kuro",
+        age = 15,
+        power = "Thunder Beats",
+        description = "Cool jacket, cooler moves. Kuro never backs down from a challenge."
+    ),
+
+    MIKO(
+        displayName = "Miko",
+        age = 11,
+        power = "Leaf Turns",
+        description = "Energetic, cheerful, and faster than a leaf in the wind. Miko can turn any trivia into a giggle-fest."
+    ),
+
+    AORI(
+        displayName = "Aori",
+        age = 13,
+        power = "Blade Echoes",
+        description = "The sword chooses the wielder—and it chose Aori. Calm, focused."
+    ),
+
+    NARA(
+        displayName = "Nara",
+        age = 12,
+        power = "Crystal Songs",
+        description = "Part magic, part sass. Nara sparkles even when she’s mad."
+    ),
+
+    RENJI(
+        displayName = "Renji",
+        age = 11,
+        power = "Hero Coins",
+        description = "Small but mighty! Renji dreams of glory, carries a shield too big for him."
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 agp = "8.13.0"
+datastorePreferences = "1.1.7"
+gson = "2.13.2"
 kotlin = "2.0.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"
@@ -15,6 +17,9 @@ coreSplashscreen = "1.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastorePreferences" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
# What does this PR do?
- Create a `QurioPreferences` class to manage preferences read/write operations.
- Expose suspend functions or flows for observing preferences changes (e.g., characterFlow, isSoundEnabled()).
- Include appropriate default values if preferences are not yet set.
